### PR TITLE
exposing `asyncDownload` option to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Options:
                           proxy.                                   [default: ""]
   --download, -d          Download video posts to the folder with the name input
                           [id]                        [boolean] [default: false]
+  --asyncDownload, -a     Number of concurrent downloads   [number] [default: 5]
   --hd                    Download video in HD. Video size will be x5-x10 times
                           larger and this will affect scraper execution speed.
                           This option only works in combination with -w flag

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Options:
                           proxy.                                   [default: ""]
   --download, -d          Download video posts to the folder with the name input
                           [id]                        [boolean] [default: false]
-  --asyncDownload, -a     Number of concurrent downloads   [number] [default: 5]
+  --asyncDownload, -a     Number of concurrent downloads            [default: 5]
   --hd                    Download video in HD. Video size will be x5-x10 times
                           larger and this will affect scraper execution speed.
                           This option only works in combination with -w flag

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -118,6 +118,11 @@ yargs
             default: false,
             describe: 'Download video posts to the folder with the name input [id]',
         },
+        asyncDownload: {
+            alias: 'a',
+            default: 5,
+            describe: 'Number of concurrent downloads',
+        },
         hd: {
             boolean: true,
             default: false,


### PR DESCRIPTION
This feature is currently undocumented in the command-line options, but it works as intended.