### PR TITLE
use stdout instead of sterr

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -177,7 +177,7 @@ export class TikTokScraper extends EventEmitter {
         this.event = event;
         this.scrapeType = type;
         this.cli = cli;
-        this.spinner = ora('TikTok Scraper Started');
+        this.spinner = ora({ text: 'TikTok Scraper Started', stream: process.stdout });
         this.byUserId = by_user_id;
         this.storeHistory = cli && download && store_history;
         this.historyPath = process.env.SCRAPING_FROM_DOCKER ? '/usr/app/files' : historyPath || tmpdir();


### PR DESCRIPTION
by default ora outputs logs to `stderr` which causes implementations using `exec` to throw:

`{ stdout: '', stderr: '- TikTok Scraper Started\n' }`

This option will output the ora stream to `stdout` and fix the false positive error. see https://www.npmjs.com/package/ora/v/3.4.0#stream