### PR TITLE
improve async tests & enable type checking everywhere

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,5 +29,11 @@ module.exports = {
                 '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
             },
         },
+        {
+          files: ['*.test.ts'],
+          env: {
+            jest: true
+          }
+        }
     ],
 };

--- a/src/core/TikTok.test.ts
+++ b/src/core/TikTok.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import fs from 'fs';
 import { ScrapeType, Result, RequestQuery, Challenge, UserData, PostCollector } from '../types';
 import { TikTokScraper } from './TikTok';
@@ -294,11 +293,7 @@ describe('TikTok Scraper MODULE(promise): signUrl', () => {
 
     it('Throw error if input url is empty', async () => {
         instance.input = '';
-        try {
-            await instance.signUrl();
-        } catch (error) {
-            expect(error).toEqual(`Url is missing`);
-        }
+        await expect(instance.signUrl()).rejects.toBe(`Url is missing`);
     });
 });
 
@@ -336,20 +331,12 @@ describe('TikTok Scraper MODULE(promise): getHashtagInfo', () => {
 
     it('Throw error if input hashtag is empty', async () => {
         instance.input = '';
-        try {
-            await instance.getHashtagInfo();
-        } catch (error) {
-            expect(error).toEqual(`Hashtag is missing`);
-        }
+        await expect(instance.getHashtagInfo()).rejects.toBe(`Hashtag is missing`);
     });
 
     it(`Throw error if hashtag doesn't exist`, async () => {
         instance.input = 'na';
-        try {
-            await instance.getHashtagInfo();
-        } catch (error) {
-            expect(error).toEqual(`Can't find hashtag: na`);
-        }
+        await expect(instance.getHashtagInfo()).rejects.toBe(`Can't find hashtag: na`);
     });
 });
 
@@ -392,20 +379,12 @@ describe('TikTok Scraper MODULE(promise): getUserProfileInfo', () => {
 
     it('Throw error if input username is empty', async () => {
         instance.input = '';
-        try {
-            await instance.getUserProfileInfo();
-        } catch (error) {
-            expect(error).toEqual(`Username is missing`);
-        }
+        await expect(instance.getUserProfileInfo()).rejects.toBe(`Username is missing`);
     });
 
     it(`Throw error if username doesn't exist`, async () => {
         instance.input = 'na';
-        try {
-            await instance.getUserProfileInfo();
-        } catch (error) {
-            expect(error).toEqual(`Can't find user: na`);
-        }
+        await expect(instance.getUserProfileInfo()).rejects.toBe(`Can't find user: na`);
     });
 });
 
@@ -500,19 +479,11 @@ describe('TikTok Scraper MODULE(promise): getVideoMeta', () => {
 
     it('Throw error if input url is empty', async () => {
         instance.input = '';
-        try {
-            await instance.getVideoMeta();
-        } catch (error) {
-            expect(error).toEqual(`Url is missing`);
-        }
+        await expect(instance.getVideoMeta()).rejects.toBe(`Url is missing`);
     });
 
     it(`Throw error if user has provided incorrect URL`, async () => {
         instance.input = 'na';
-        try {
-            await instance.getVideoMeta();
-        } catch (error) {
-            expect(error).toEqual(`Can't extract metadata from the video: na`);
-        }
+        await expect(instance.getVideoMeta()).rejects.toBe(`Can't extract metadata from the video: na`);
     });
 });

--- a/src/helpers/Bar.ts
+++ b/src/helpers/Bar.ts
@@ -1,9 +1,15 @@
-// @ts-nocheck
-/* eslint-disable */
 import ProgressBar from 'progress';
 import * as readline from 'readline';
 
 export class MultipleBar {
+    public stream: any;
+
+    public cursor: number;
+
+    public bars: ProgressBar[];
+
+    public terminates: number;
+
     constructor() {
         this.stream = process.stderr;
         this.cursor = 1;
@@ -12,6 +18,7 @@ export class MultipleBar {
     }
 
     newBar(schema, options) {
+        // eslint-disable-next-line no-param-reassign
         options.stream = this.stream;
         const bar = new ProgressBar(schema, options);
         this.bars.push(bar);
@@ -23,16 +30,16 @@ export class MultipleBar {
         this.cursor += 1;
 
         // replace original
-        const self = this;
-        bar.otick = bar.tick;
-        bar.oterminate = bar.terminate;
-        bar.tick = (value, options) => {
-            self.tick(index, value, options);
+        const barObj = bar as any;
+        barObj.otick = bar.tick;
+        barObj.oterminate = bar.terminate;
+        barObj.tick = (value, opts) => {
+            this.tick(index, value, opts);
         };
-        bar.terminate = () => {
-            self.terminates += 1;
-            if (self.terminates === self.bars.length) {
-                self.terminate();
+        barObj.terminate = () => {
+            this.terminates += 1;
+            if (this.terminates === this.bars.length) {
+                this.terminate();
             }
         };
 
@@ -42,7 +49,7 @@ export class MultipleBar {
     terminate() {
         this.move(this.bars.length);
 
-        readline.clearLine();
+        readline.clearLine(this.stream, 0);
         if (!this.stream.isTTY) return;
         this.stream.cursorTo(0);
     }
@@ -57,7 +64,7 @@ export class MultipleBar {
         const bar = this.bars[index];
         if (bar) {
             this.move(index);
-            bar.otick(value, options);
+            (bar as any).otick(value, options);
         }
     }
 }


### PR DESCRIPTION
Basically:

* Removed all but one of the `ts-disable` flags
* Removed all but one of the `eslint-disable` flags
* Added an editorconfig file
* Enabled the `jest`  ESLint env for `*.test.ts`
* Changed a few async tests to use `expect(...).rejects.toBe(...)`
* Got rid of `self` in the Bar class (its in an arrow function, its scope is already the right `this`)
* Added the correct arguments to `clearLine` (presumably stderr/`this.stream` was what you were trying to clear)

For the async tests, we had this:

```ts
try {
  await doSomething();
} catch (err) {
  expect(err).toBe('something');
}
```

this meant if `doSomething` resolved, it would pass the test but be wrong.

let me know if you're interested in these changes.