### PR TITLE
Warn about failing to download video without watermark

### DIFF
--- a/src/core/Downloader.ts
+++ b/src/core/Downloader.ts
@@ -181,18 +181,19 @@ export class Downloader {
      */
     public async downloadSingleVideo(post: PostCollector) {
         const proxy = this.getProxy;
+        let url = post.videoUrlNoWaterMark;
+        if (!url) {
+            url = post.videoUrl;
+        }
         const options = ({
-            uri: post.videoUrlNoWaterMark,
+            uri: url,
             encoding: null,
             ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
             ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
         } as unknown) as OptionsWithUri;
-        try {
-            const result = await rp(options);
 
-            await fromCallback(cb => writeFile(`${this.filepath}/${post.id}.mp4`, result, cb));
-        } catch (error) {
-            throw error.message;
-        }
+        const result = await rp(options);
+
+        await fromCallback(cb => writeFile(`${this.filepath}/${post.id}.mp4`, result, cb));
     }
 }

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable no-throw-literal */
 /* eslint-disable no-await-in-loop */
 import rp, { OptionsWithUri } from 'request-promise';
@@ -392,7 +393,7 @@ export class TikTokScraper extends EventEmitter {
      * @param uri
      */
     // eslint-disable-next-line class-methods-use-this
-    private async extractVideoId(uri): Promise<string> {
+    private async extractVideoId(uri): Promise<string | null> {
         try {
             const result = await rp({ uri });
             const position = Buffer.from(result).indexOf('vid:');
@@ -404,10 +405,11 @@ export class TikTokScraper extends EventEmitter {
                     this.hdVideo ? `&ratio=default&improve_bitrate=1` : ''
                 }`;
             }
-            throw new Error(`Cant extract video id`);
         } catch (error) {
-            return '';
+            console.error(error);
         }
+        console.warn(`Couldn't get video without watermark`);
+        return null;
     }
 
     /**
@@ -1104,7 +1106,7 @@ export class TikTokScraper extends EventEmitter {
                     },
                     imageUrl: videoData.itemInfos.coversOrigin[0],
                     videoUrl: videoData.itemInfos.video.urls[0],
-                    videoUrlNoWaterMark: '',
+                    videoUrlNoWaterMark: null,
                     videoMeta: videoData.itemInfos.video.videoMeta,
                     covers: {
                         default: videoData.itemInfos.covers[0],

--- a/src/types/TikTok.ts
+++ b/src/types/TikTok.ts
@@ -119,7 +119,7 @@ export interface PostCollector {
     imageUrl?: string;
     webVideoUrl?: string;
     videoUrl: string;
-    videoUrlNoWaterMark: string;
+    videoUrlNoWaterMark: string | null;
     videoMeta: {
         width: number;
         height: number;


### PR DESCRIPTION
When failing to download `--noWaterMark` warn about it as I want to know this, rather than appearing that everything worked.

Also fix error and fallback for single `video`. Currently I got this message without any backtrace. It's really terrible idea to swallow exceptions.

```
$ tiktok-scraper video $VID -d
Error: options.uri is a required argument
```
