### PR TITLE
flip comment and playcount into the correct place

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1163,8 +1163,8 @@ export class TikTokScraper extends EventEmitter {
                     },
                     diggCount: videoData.stats.diggCount,
                     shareCount: videoData.stats.shareCount,
-                    playCount: videoData.stats.commentCount,
-                    commentCount: videoData.stats.playCount,
+                    playCount: videoData.stats.playCount,
+                    commentCount: videoData.stats.commentCount,
                     downloaded: false,
                     mentions: videoData.desc.match(/(@\w+)/g) || [],
                     hashtags: videoData.challenges


### PR DESCRIPTION
In videoItem the comments and play count are swapped. put them back into the right order