### PR TITLE
change INIT_OPTIONS to a non-constant & change verifyFp

### DIFF
--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -24,7 +24,7 @@ export = {
      * later I or someone else will implement proper way to generate valid value
      */
     verifyFp: () => {
-        const variants = [];
+        const variants = ['verify_khpndkhf_ERut2lgl_kAb1_4TM1_9Zp3_4bG4cYoT86xY'];
 
         return variants[Math.floor(Math.random() * variants.length)];
     },

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -22,29 +22,31 @@ import {
 import CONST from './constant';
 import { makeid } from './helpers';
 
-const INIT_OPTIONS = {
-    number: 30,
-    download: false,
-    zip: false,
-    asyncDownload: 5,
-    asyncScraping: 3,
-    proxy: [],
-    filepath: process.cwd(),
-    filetype: 'na',
-    progress: false,
-    event: false,
-    by_user_id: false,
-    noWaterMark: false,
-    hdVideo: false,
-    timeout: 0,
-    tac: '',
-    signature: '',
-    verifyFp: CONST.verifyFp(),
-    headers: {
-        'User-Agent': CONST.userAgent(),
-        Referer: 'https://www.tiktok.com/',
-        Cookie: `tt_webid_v2=68${makeid(16)}`,
-    },
+const getInitOptions = () => {
+    return {
+        number: 30,
+        download: false,
+        zip: false,
+        asyncDownload: 5,
+        asyncScraping: 3,
+        proxy: [],
+        filepath: process.cwd(),
+        filetype: 'na',
+        progress: false,
+        event: false,
+        by_user_id: false,
+        noWaterMark: false,
+        hdVideo: false,
+        timeout: 0,
+        tac: '',
+        signature: '',
+        verifyFp: CONST.verifyFp(),
+        headers: {
+            'User-Agent': CONST.userAgent(),
+            Referer: 'https://www.tiktok.com/',
+            Cookie: `tt_webid_v2=68${makeid(16)}`,
+        }
+    }
 };
 
 /**
@@ -73,7 +75,7 @@ const promiseScraper = async (input: string, type: ScrapeType, options = {} as O
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
 
-    const constructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type, input } };
+    const constructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type, input } };
 
     const scraper = new TikTokScraper(constructor);
 
@@ -86,7 +88,7 @@ const eventScraper = (input: string, type: ScrapeType, options = {} as Options):
         throw new TypeError('Object is expected');
     }
 
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type, input, event: true } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type, input, event: true } };
     return new TikTokScraper(contructor);
 };
 
@@ -108,7 +110,7 @@ export const getHashtagInfo = async (input: string, options = {} as Options): Pr
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
 
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'signle_hashtag' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'signle_hashtag' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
 
     const result = await scraper.getHashtagInfo();
@@ -123,7 +125,7 @@ export const getMusicInfo = async (input: string, options = {} as Options): Prom
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
 
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'single_music' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'single_music' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
 
     const result = await scraper.getMusicInfo();
@@ -138,7 +140,7 @@ export const getUserProfileInfo = async (input: string, options = {} as Options)
     if (options?.proxyFile) {
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'sinsgle_user' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'sinsgle_user' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
 
     const result = await scraper.getUserProfileInfo();
@@ -153,7 +155,7 @@ export const signUrl = async (input: string, options = {} as Options): Promise<s
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
 
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'signature' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'signature' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
 
     const result = await scraper.signUrl();
@@ -168,7 +170,7 @@ export const getVideoMeta = async (input: string, options = {} as Options): Prom
     if (options?.proxyFile) {
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'video_meta' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'video_meta' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
 
     const result = await scraper.getVideoMeta();
@@ -186,7 +188,7 @@ export const video = async (input: string, options = {} as Options): Promise<any
     if (options?.proxyFile) {
         options.proxy = await proxyFromFile(options?.proxyFile);
     }
-    const contructor: TikTokConstructor = { ...INIT_OPTIONS, ...options, ...{ type: 'video' as ScrapeType, input } };
+    const contructor: TikTokConstructor = { ...getInitOptions(), ...options, ...{ type: 'video' as ScrapeType, input } };
     const scraper = new TikTokScraper(contructor);
     const result: PostCollector = await scraper.getVideoMeta();
 


### PR DESCRIPTION

After using the same agent or cookie to access the API multiple times, an error of code 10000 will appear. It doesn’t matter for a single script, but not for a long-lived server