### PR TITLE
Skip existing files, add more details to filename.

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -251,7 +251,7 @@ export const video = async (input: string, options = {} as Options): Promise<any
     }
 
     return {
-        ...(options?.download ? { message: `Video location: ${contructor.filepath}/${result.id}.mp4` } : {}),
+        ...(options?.download ? { message: `Video location: ${contructor.filepath}/${result.authorMeta.name} ${result.text} ${result.id}.mp4` } : {}),
         ...outputMessage,
     };
 };


### PR DESCRIPTION
Added author and title to the filename

It will search for any file with the id, if such file is found it will not redownload it, this has no dependencies on traking

This ignores extensions, so if you don't want a video to be redownloaded you can just create a txt file with the id in it and it will be skipped

This doesn't ignore any files (json files), if the json file exists this change will consider it to be an idication that it was already 
downloaded and will not download the video

I am not sure this is ready to be merged. Please discuss.