### PR TITLE
Fix signing URL encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tiktok-scraper",
-    "version": "1.4.22",
+    "version": "1.4.23",
     "description": "TikTok Scraper & Downloader. Scrape information from User, Trending and HashTag pages and download video posts",
     "main": "./build/index.js",
     "types": "./build/index.d.ts",

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -809,7 +809,7 @@ export class TikTokScraper extends EventEmitter {
         this.storeValue = this.scrapeType === 'trend' ? 'trend' : qs.id || qs.challengeID! || qs.musicID!;
 
         const query: any = qs;
-        const unsignedURL = `${this.getApiEndpoint}?${new URLSearchParams(query).toString()}`;
+        const unsignedURL = `${this.getApiEndpoint}?${new URLSearchParams(query).toString().replace(/\+/g, '%20')}`;
         const _signature = sign(this.headers['user-agent'], unsignedURL);
         qs._signature = _signature;
 


### PR DESCRIPTION
This fixes a bug in #534 (fix for #525) where the URL to the signing function was encoded differently than the actual request, causing issues with some methods.
I bumped the version again as well (since 1.4.22 is already in use).