### PR TITLE
Alpine has musl and not glibc so we need to build stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM alpine:latest AS tiktok_scraper.build
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3
+RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev 
+RUN apk add --update cairo-dev pango-dev make g++
 
 COPY package*.json tsconfig.json .prettierrc.js bin ./
 COPY ./src ./src
@@ -18,7 +19,8 @@ FROM alpine:latest AS tiktok_scraper.use
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm
+RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev
+RUN apk add --update cairo-dev pango-dev make g++
 
 COPY --from=tiktok_scraper.build ./usr/app ./
 COPY ./bin ./bin


### PR DESCRIPTION
Docker won't build for me because of the following:

node-pre-gyp WARN Using request for node-pre-gyp https download 
node-pre-gyp WARN Tried to download(404): https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v72-linux-musl-x64.tar.gz 
node-pre-gyp WARN Pre-built binaries not found for canvas@2.7.0 and node@12.22.1 (node-v72 ABI, musl) (falling back to source compile with node-gyp) 

Alpine has musl and not glibc so no prebuilt canvas for us!

Dockerfile has been adjusted to allow compilation.