### PR TITLE
Feature strictSSL: Add rejectUnauthorized option in promise-request call

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -54,6 +54,8 @@ export class TikTokScraper extends EventEmitter {
 
     private proxy: string[] | string;
 
+    private strictSSL: boolean;
+
     private number: number;
 
     private asyncDownload: number;
@@ -128,6 +130,7 @@ export class TikTokScraper extends EventEmitter {
         filepath,
         filetype,
         proxy,
+        strictSSL = true,
         asyncDownload,
         cli = false,
         event = false,
@@ -165,6 +168,7 @@ export class TikTokScraper extends EventEmitter {
         this.input = input;
         this.test = test;
         this.proxy = proxy;
+        this.strictSSL = strictSSL;
         this.number = number;
         this.csrf = '';
         this.zip = zip;
@@ -333,6 +337,7 @@ export class TikTokScraper extends EventEmitter {
                 simple,
                 ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
                 ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
+                ...(this.strictSSL === false ? { rejectUnauthorized: false } : {}),
                 timeout: 10000,
             } as unknown) as OptionsWithUri;
 

--- a/src/types/TikTok.ts
+++ b/src/types/TikTok.ts
@@ -56,6 +56,7 @@ export interface TikTokConstructor {
     filetype: string;
     useTestEndpoints?: boolean;
     proxy: string[] | string;
+    strictSSL?: boolean;
     asyncDownload: number;
     asyncScraping: number;
     cli?: boolean;


### PR DESCRIPTION
https://github.com/drawrowfly/tiktok-scraper/issues/538
@bblack says:

**Is your feature request related to a problem? Please describe.**
Our http proxy uses a self-signed certificate. When specifying the location of that proxy in tiktok-scraper's proxy option, the requests fail and the collector returns an empty array.

**Describe the solution you'd like**
I'd like to be able to pass, along with the proxy option, a new option `strictSSL: false`. Since tiktok-scraper uses the request-promise package, which is built atop the request package and takes the same options, passing `strictSSL: false` would allow the self-signed certificate to be accepted, and the collector will be successfully populated.


I have to add `rejectUnauthorized` param in `promise-request` options