### PR TITLE
No `nodejs-npm` in latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest AS tiktok_scraper.build
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev 
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev 
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY package*.json tsconfig.json .prettierrc.js bin ./
@@ -19,7 +19,7 @@ FROM alpine:latest AS tiktok_scraper.use
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY --from=tiktok_scraper.build ./usr/app ./


### PR DESCRIPTION
I was getting an error while I trying to build the image from your `Dockerfile`. However, I found the issue is coming from `nodejs-npm` that is no longer available.

I changed `nodejs-npm` to `npm` and everything worked as expected.