### PR TITLE
propagate errors inside `forEachLimit`

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -611,7 +611,8 @@ export class TikTokScraper extends EventEmitter {
             const { done } = await this.collectPosts(updatedApiResponse ? result.itemList : result.items);
 
             if (!hasMore) {
-                throw new Error('No more posts');
+                console.error(`Only ${this.collector.length} results could be found.`);
+                return true;
             }
 
             if (done) {

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -554,25 +554,25 @@ export class TikTokScraper extends EventEmitter {
                         case 'user':
                             this.getUserId()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: this.maxCursor }, true))
-                                .then(kill => cb(kill))
+                                .then(kill => cb(kill || null))
                                 .catch(error => cb(error));
                             break;
                         case 'hashtag':
                             this.getHashTagId()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: item === 1 ? 0 : (item - 1) * query.count! }, true))
-                                .then(kill => cb(kill))
+                                .then(kill => cb(kill || null))
                                 .catch(error => cb(error));
                             break;
                         case 'trend':
                             this.getTrendingFeedQuery()
                                 .then(query => this.submitScrapingRequest({ ...query }, true))
-                                .then(kill => cb(kill))
+                                .then(kill => cb(kill || null))
                                 .catch(error => cb(error));
                             break;
                         case 'music':
                             this.getMusicFeedQuery()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: item === 1 ? 0 : (item - 1) * query.count! }, true))
-                                .then(kill => cb(kill))
+                                .then(kill => cb(kill || null))
                                 .catch(error => cb(error));
                             break;
                         default:

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -554,25 +554,25 @@ export class TikTokScraper extends EventEmitter {
                         case 'user':
                             this.getUserId()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: this.maxCursor }, true))
-                                .then(() => cb(null))
+                                .then(kill => cb(kill))
                                 .catch(error => cb(error));
                             break;
                         case 'hashtag':
                             this.getHashTagId()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: item === 1 ? 0 : (item - 1) * query.count! }, true))
-                                .then(() => cb(null))
+                                .then(kill => cb(kill))
                                 .catch(error => cb(error));
                             break;
                         case 'trend':
                             this.getTrendingFeedQuery()
                                 .then(query => this.submitScrapingRequest({ ...query }, true))
-                                .then(() => cb(null))
+                                .then(kill => cb(kill))
                                 .catch(error => cb(error));
                             break;
                         case 'music':
                             this.getMusicFeedQuery()
                                 .then(query => this.submitScrapingRequest({ ...query, cursor: item === 1 ? 0 : (item - 1) * query.count! }, true))
-                                .then(() => cb(null))
+                                .then(kill => cb(kill))
                                 .catch(error => cb(error));
                             break;
                         default:
@@ -580,7 +580,7 @@ export class TikTokScraper extends EventEmitter {
                     }
                 },
                 err => {
-                    if (err) {
+                    if (err && err !== true) {
                         return reject(err);
                     }
 
@@ -594,7 +594,7 @@ export class TikTokScraper extends EventEmitter {
      * Submit request to the TikTok web API
      * Collect received metadata
      */
-    private async submitScrapingRequest(query: RequestQuery, updatedApiResponse = false): Promise<any> {
+    private async submitScrapingRequest(query: RequestQuery, updatedApiResponse = false): Promise<boolean> {
         try {
             if (!this.validHeaders) {
                 await this.getValidHeaders(this.getApiEndpoint);
@@ -615,9 +615,11 @@ export class TikTokScraper extends EventEmitter {
             }
 
             if (done) {
-                throw new Error('Done');
+                return true;
             }
+
             this.maxCursor = parseInt(maxCursor === undefined ? cursor : maxCursor, 10);
+            return false;
         } catch (error) {
             throw error.message ? error.message : error;
         }

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -453,7 +453,7 @@ export class TikTokScraper extends EventEmitter {
      * Extract uniq video id and create the url to the video without the watermark
      */
     private withoutWatermark() {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             forEachLimit(
                 this.collector,
                 5,
@@ -465,7 +465,11 @@ export class TikTokScraper extends EventEmitter {
                         throw new Error(`Can't extract unique video id`);
                     }
                 },
-                () => {
+                err => {
+                    if (err) {
+                        return reject(err);
+                    }
+
                     resolve(null);
                 },
             );
@@ -540,7 +544,7 @@ export class TikTokScraper extends EventEmitter {
      * Main loop that collects all required metadata from the tiktok web api
      */
     private mainLoop(): Promise<any> {
-        return new Promise(resolve => {
+        return new Promise((resolve, reject) => {
             const taskArray = Array.from({ length: 1000 }, (v, k) => k + 1);
             forEachLimit(
                 taskArray,
@@ -575,7 +579,11 @@ export class TikTokScraper extends EventEmitter {
                             break;
                     }
                 },
-                () => {
+                err => {
+                    if (err) {
+                        return reject(err);
+                    }
+
                     resolve(null);
                 },
             );


### PR DESCRIPTION
Calls to `forEachLimit` are not propagating errors thrown inside the `iteratee`. This PR should fix the issue.