### PR TITLE
Improved error messages

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -66,7 +66,7 @@ const startScraper = async argv => {
                 console.log(scraper);
             }
         } catch (error) {
-            console.error(error.message ? error.message : error);
+            console.error(error.message || error);
         }
     } catch (error) {
         console.log(error);

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1044,7 +1044,7 @@ export class TikTokScraper extends EventEmitter {
         await this.getValidHeaders(`https://www.tiktok.com/@${encodeURIComponent(this.input)}`, false);
 
         if (!this.input) {
-            throw `Username is missing`;
+            throw new Error(`Username is missing`);
         }
         const options = {
             method: 'GET',
@@ -1074,7 +1074,7 @@ export class TikTokScraper extends EventEmitter {
      */
     public async getHashtagInfo(): Promise<HashtagMetadata> {
         if (!this.input) {
-            throw `Hashtag is missing`;
+            throw new Error(`Hashtag is missing`);
         }
         const query = {
             uri: `${this.mainHost}node/share/tag/${this.input}?uniqueId=${this.input}`,
@@ -1106,7 +1106,7 @@ export class TikTokScraper extends EventEmitter {
     public async getMusicInfo(): Promise<MusicMetadata> {
         await this.getValidHeaders(this.input, false);
         if (!this.input) {
-            throw `Music is missing`;
+            throw new Error(`Music is missing`);
         }
 
         const musicTitle = /music\/([\w-]+)-\d+/.exec(this.input);
@@ -1160,7 +1160,7 @@ export class TikTokScraper extends EventEmitter {
      */
     public async signUrl() {
         if (!this.input) {
-            throw `Url is missing`;
+            throw new Error(`Url is missing`);
         }
         return sign(this.input, this.headers['user-agent']);
     }
@@ -1190,7 +1190,7 @@ export class TikTokScraper extends EventEmitter {
             const videoData = videoProps.props.pageProps.itemInfo.itemStruct;
             return videoData as FeedItems;
         } catch (error) {
-            throw `Can't extract video metadata: ${this.input}`;
+            throw new Error(`Can't extract video metadata: ${this.input}`);
         }
     }
 
@@ -1231,7 +1231,7 @@ export class TikTokScraper extends EventEmitter {
     public async getVideoMeta(html = true): Promise<PostCollector> {
         await this.getValidHeaders(this.input, false);
         if (!this.input) {
-            throw `Url is missing`;
+            throw new Error(`Url is missing`);
         }
 
         let videoData = {} as FeedItems;

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -611,7 +611,7 @@ export class TikTokScraper extends EventEmitter {
             }
             this.maxCursor = parseInt(maxCursor === undefined ? cursor : maxCursor, 10);
         } catch (error) {
-            throw error.message ? error.message : error;
+            throw error.message ? new Error(error.message) : error;
         }
     }
 
@@ -890,7 +890,7 @@ export class TikTokScraper extends EventEmitter {
         try {
             await this.request<string>(options);
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 
@@ -914,7 +914,7 @@ export class TikTokScraper extends EventEmitter {
             const response = await this.request<T>(options);
             return response;
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 
@@ -988,7 +988,7 @@ export class TikTokScraper extends EventEmitter {
                 verifyFp: this.verifyFp,
             };
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 
@@ -1032,7 +1032,7 @@ export class TikTokScraper extends EventEmitter {
                 is_fullscreen: false,
             };
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 
@@ -1095,7 +1095,7 @@ export class TikTokScraper extends EventEmitter {
             }
             return response.challengeInfo;
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 
@@ -1150,7 +1150,7 @@ export class TikTokScraper extends EventEmitter {
             }
             return response.musicInfo;
         } catch (error) {
-            throw error.message;
+            throw new Error(error.message);
         }
     }
 

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -62,7 +62,7 @@ const proxyFromFile = async (file: string) => {
         }
         return proxyList;
     } catch (error) {
-        throw error.message;
+        throw new Error(error.message);
     }
 };
 
@@ -79,7 +79,7 @@ const sessionFromFile = async (file: string) => {
         }
         return proxyList;
     } catch (error) {
-        throw error.message;
+        throw new Error(error.message);
     }
 };
 


### PR DESCRIPTION
*  fix 'no-throw-literal' cases:
https://eslint.org/docs/rules/no-throw-literal

* add stacktrace to errors:
Using `throw new Error(error.message)` instead of `throw error.message` makes the error easier to trace.

---

In other words, this:
```haskell
Error: Error: tunneling socket could not be established, statusCode=402
    at TikTokScraper.getHashTagId (/tiktok-scraper/build/core/TikTok.js:649:19)
```

is less cryptic than this:
```haskell
Error: tunneling socket could not be established, statusCode=402
```