### PR TITLE
fix collection of posts with matching `count`

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -770,12 +770,6 @@ export class TikTokScraper extends EventEmitter {
             if (result.done) {
                 break;
             }
-            if (this.number) {
-                if (this.collector.length >= this.number) {
-                    result.done = true;
-                    break;
-                }
-            }
 
             if (this.since && posts[i].createTime < this.since) {
                 result.done = CONST.chronologicalTypes.indexOf(this.scrapeType) !== -1;
@@ -860,6 +854,13 @@ export class TikTokScraper extends EventEmitter {
                     this.collector.push({} as PostCollector);
                 } else {
                     this.collector.push(item);
+                }
+            }
+
+            if (this.number) {
+                if (this.collector.length >= this.number) {
+                    result.done = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Calls in which the option `number` matches the value of the `Query`'s `count` (inside `scrapeData`) have an unnecessary extra call.

For instance,  the call below will collect 29 posts instead of 30 in the first run. Then `submitScrapingRequest` will be called a second time just to collect that 30th post that should have been already collected on the first call.

```js
const posts = await TikTokScraper.hashtag('HASHTAG', {
    number: 30,
    sessionList: ['sid_tt=58ba9e34431774703d3c34e60d584475;']
});
```