### PR TITLE
add filePath to Downloader

### DIFF
--- a/src/core/Downloader.ts
+++ b/src/core/Downloader.ts
@@ -27,18 +27,21 @@ export class Downloader {
 
     public filepath: string;
 
+    public fileName: string;
+
     public bulk: boolean;
 
     public headers: Headers;
 
     public cookieJar: CookieJar;
 
-    constructor({ progress, proxy, noWaterMark, headers, filepath, bulk, cookieJar }: DownloaderConstructor) {
+    constructor({ progress, proxy, noWaterMark, headers, filepath, fileName, bulk, cookieJar }: DownloaderConstructor) {
         this.progress = true || progress;
         this.progressBar = [];
         this.noWaterMark = noWaterMark;
         this.headers = headers;
         this.filepath = filepath;
+        this.fileName = fileName
         this.mbars = new MultipleBar();
         this.proxy = proxy;
         this.bulk = bulk;
@@ -209,6 +212,6 @@ export class Downloader {
 
         const result = await rp(options);
 
-        await fromCallback(cb => writeFile(`${this.filepath}/${post.id}.mp4`, result, cb));
+        await fromCallback(cb => writeFile(`${this.filepath}/${this.fileName || post.id}.mp4`, result, cb));
     }
 }

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -212,6 +212,7 @@ export class TikTokScraper extends EventEmitter {
             noWaterMark,
             headers,
             filepath: process.env.SCRAPING_FROM_DOCKER ? '/usr/app/files' : filepath || '',
+            fileName: fileName,
             bulk,
         });
         this.webHookUrl = webHookUrl;

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -251,7 +251,7 @@ export const video = async (input: string, options = {} as Options): Promise<any
     }
 
     return {
-        ...(options?.download ? { message: `Video location: ${contructor.filepath}/${result.id}.mp4` } : {}),
+        ...(options?.download ? { message: `Video location: ${path}.mp4` } : {}),
         ...outputMessage,
     };
 };

--- a/src/types/Downloader.ts
+++ b/src/types/Downloader.ts
@@ -7,6 +7,7 @@ export interface DownloaderConstructor {
     noWaterMark: boolean;
     headers: Headers;
     filepath: string;
+    fileName: string;
     bulk: boolean;
     cookieJar: CookieJar;
 }


### PR DESCRIPTION
I was trying to use the `video` with a filePath option and I noticed it wasn't being used in the Downloader code (it's using `post.id`). I see that there is the use of a zip file in the Downloader that also uses post.id that I'm unsure of would be useful by renaming each file inside the same name.

This does allow some consistency with single video downloading as the file names for the json, csv, mp4, etc. will all be the same. 
