### PR TITLE
fix `since` in collectPosts

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -779,7 +779,12 @@ export class TikTokScraper extends EventEmitter {
 
             if (this.since && posts[i].createTime < this.since) {
                 result.done = CONST.chronologicalTypes.indexOf(this.scrapeType) !== -1;
-                break;
+
+                if (result.done) {
+                    break;
+                } else {
+                    continue;
+                }
             }
 
             if (this.noDuplicates.indexOf(posts[i].id) === -1) {


### PR DESCRIPTION
The `since` option only works well for calls to `user`. All other requests with `since` will only check 1 post per request and then `break` the loop while ignoring all the other results.