### PR TITLE
[Feature] retry failing request before giving up

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -125,6 +125,10 @@ yargs
             default: 0,
             describe: 'Set timeout between requests. Timeout is in Milliseconds: 1000 mls = 1 s',
         },
+        retry: {
+            default: 3,
+            describe: 'Set the amount of times a failing request should be retried before giving up',
+        },
         number: {
             alias: 'n',
             default: 0,

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "jsdom": "^16.5.3",
         "json2csv": "4.5.1",
         "ora": "^4.0.2",
+        "p-retry": "^4.6.1",
         "progress": "^2.0.3",
         "request": "^2.88.0",
         "request-promise": "^4.2.4",

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -13,6 +13,7 @@ import { EventEmitter } from 'events';
 import { SocksProxyAgent } from 'socks-proxy-agent';
 import { forEachLimit } from 'async';
 import { URLSearchParams } from 'url';
+import pRetry from 'p-retry';
 import CONST from '../constant';
 import { sign, makeid } from '../helpers';
 
@@ -94,6 +95,8 @@ export class TikTokScraper extends EventEmitter {
 
     private timeout: number;
 
+    private retry: number;
+
     private bulk: boolean;
 
     private validHeaders: boolean;
@@ -148,6 +151,7 @@ export class TikTokScraper extends EventEmitter {
         useTestEndpoints = false,
         fileName = '',
         timeout = 0,
+        retry = 3,
         bulk = false,
         zip = false,
         test = false,
@@ -203,6 +207,7 @@ export class TikTokScraper extends EventEmitter {
         this.maxCursor = 0;
         this.noDuplicates = [];
         this.timeout = timeout;
+        this.retry = retry;
         this.bulk = bulk;
         this.validHeaders = false;
         this.Downloader = new Downloader({
@@ -210,6 +215,7 @@ export class TikTokScraper extends EventEmitter {
             cookieJar: this.cookieJar,
             proxy,
             noWaterMark,
+            retry,
             headers,
             filepath: process.env.SCRAPING_FROM_DOCKER ? '/usr/app/files' : filepath || '',
             bulk,
@@ -320,57 +326,64 @@ export class TikTokScraper extends EventEmitter {
         bodyOnly = true,
     ): Promise<T> {
         // eslint-disable-next-line no-async-promise-executor
-        return new Promise(async (resolve, reject) => {
-            const proxy = this.getProxy;
-            const options = ({
-                jar: this.cookieJar,
-                uri,
-                method,
-                ...(qs ? { qs } : {}),
-                ...(body ? { body } : {}),
-                ...(form ? { form } : {}),
-                headers: {
-                    ...this.headers,
-                    ...headers,
-                    ...(this.csrf ? { 'x-secsdk-csrf-token': this.csrf } : {}),
-                },
-                ...(json ? { json: true } : {}),
-                ...(gzip ? { gzip: true } : {}),
-                resolveWithFullResponse: true,
-                followAllRedirects: followAllRedirects || false,
-                simple,
-                ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
-                ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
-                ...(this.strictSSL === false ? { rejectUnauthorized: false } : {}),
-                timeout: 10000,
-            } as unknown) as OptionsWithUri;
+        return pRetry(
+            () =>
+                new Promise(async (resolve, reject) => {
+                    const proxy = this.getProxy;
+                    const options = ({
+                        jar: this.cookieJar,
+                        uri,
+                        method,
+                        ...(qs ? { qs } : {}),
+                        ...(body ? { body } : {}),
+                        ...(form ? { form } : {}),
+                        headers: {
+                            ...this.headers,
+                            ...headers,
+                            ...(this.csrf ? { 'x-secsdk-csrf-token': this.csrf } : {}),
+                        },
+                        ...(json ? { json: true } : {}),
+                        ...(gzip ? { gzip: true } : {}),
+                        resolveWithFullResponse: true,
+                        followAllRedirects: followAllRedirects || false,
+                        simple,
+                        ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
+                        ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
+                        ...(this.strictSSL === false ? { rejectUnauthorized: false } : {}),
+                        timeout: 10000,
+                    } as unknown) as OptionsWithUri;
 
-            const session = this.sessionList[Math.floor(Math.random() * this.sessionList.length)];
-            if (session) {
-                this.cookieJar.setCookie(session, 'https://tiktok.com');
-            }
-            /**
-             * Set tt_webid_v2 cookie to access video url
-             */
-            const cookies = this.cookieJar.getCookieString('https://tiktok.com');
-            if (cookies.indexOf('tt_webid_v2') === -1) {
-                this.cookieJar.setCookie(`tt_webid_v2=69${makeid(17)}; Domain=tiktok.com; Path=/; Secure; hostOnly=false`, 'https://tiktok.com');
-            }
+                    const session = this.sessionList[Math.floor(Math.random() * this.sessionList.length)];
+                    if (session) {
+                        this.cookieJar.setCookie(session, 'https://tiktok.com');
+                    }
+                    /**
+                     * Set tt_webid_v2 cookie to access video url
+                     */
+                    const cookies = this.cookieJar.getCookieString('https://tiktok.com');
+                    if (cookies.indexOf('tt_webid_v2') === -1) {
+                        this.cookieJar.setCookie(
+                            `tt_webid_v2=69${makeid(17)}; Domain=tiktok.com; Path=/; Secure; hostOnly=false`,
+                            'https://tiktok.com',
+                        );
+                    }
 
-            try {
-                const response = await rp(options);
-                // Extract valid csrf token
-                if (options.method === 'HEAD') {
-                    const csrf = response.headers['x-ware-csrf-token'];
-                    this.csrf = csrf.split(',')[1] as string;
-                }
-                setTimeout(() => {
-                    resolve(bodyOnly ? response.body : response);
-                }, this.timeout);
-            } catch (error) {
-                reject(error);
-            }
-        });
+                    try {
+                        const response = await rp(options);
+                        // Extract valid csrf token
+                        if (options.method === 'HEAD') {
+                            const csrf = response.headers['x-ware-csrf-token'];
+                            this.csrf = csrf.split(',')[1] as string;
+                        }
+                        setTimeout(() => {
+                            resolve(bodyOnly ? response.body : response);
+                        }, this.timeout);
+                    } catch (error) {
+                        reject(error);
+                    }
+                }),
+            { retries: this.retry },
+        );
     }
 
     private returnInitError(error) {

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -39,6 +39,7 @@ const getInitOptions = () => {
         noWaterMark: false,
         hdVideo: false,
         timeout: 0,
+        retry: 3,
         tac: '',
         signature: '',
         verifyFp: makeVerifyFp(),

--- a/src/types/Downloader.ts
+++ b/src/types/Downloader.ts
@@ -5,6 +5,7 @@ export interface DownloaderConstructor {
     progress: boolean;
     proxy: string[] | string;
     noWaterMark: boolean;
+    retry: number;
     headers: Headers;
     filepath: string;
     bulk: boolean;

--- a/src/types/TikTok.ts
+++ b/src/types/TikTok.ts
@@ -44,6 +44,7 @@ export interface Options {
     fileName?: string;
     historyPath?: string;
     timeout?: number;
+    retry?: number;
     hdVideo?: boolean;
     randomUa?: boolean;
     webHookUrl?: string;
@@ -75,6 +76,7 @@ export interface TikTokConstructor {
     noWaterMark?: boolean;
     fileName?: string;
     timeout?: number;
+    retry?: number;
     test?: boolean;
     hdVideo?: boolean;
     signature?: string;


### PR DESCRIPTION
When using tiktok-scraper for intensive tasks, such as downloading hundreds of videos at once, it can happen that a single request fails and then the whole process is ended.

This PR let requests be retried before giving up on them. This is an effective workaround for connectivity/networking issues, and allows for customisation through the `--retry` option.