### PR TITLE
change 'nodejs-npm' to 'npm': build fail, no pkg.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest AS tiktok_scraper.build
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev 
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev 
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY package*.json tsconfig.json .prettierrc.js bin ./
@@ -19,7 +19,7 @@ FROM alpine:latest AS tiktok_scraper.use
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY --from=tiktok_scraper.build ./usr/app ./


### PR DESCRIPTION
docker build failed due to `nodejs-npm` being removed. new package `npm` tookits place and build succeeded.