### PR TITLE
Pinned Docker Build to alpine:3.14 and fixed issue of failure due to npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 #Building Scraper
-FROM alpine:latest AS tiktok_scraper.build
+FROM alpine:3.14 AS tiktok_scraper.build
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev 
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev 
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY package*.json tsconfig.json .prettierrc.js bin ./
@@ -15,11 +15,11 @@ RUN rm -rf src node_modules
 
 
 #Using Scraper
-FROM alpine:latest AS tiktok_scraper.use
+FROM alpine:3.14 AS tiktok_scraper.use
 
 WORKDIR /usr/app
 
-RUN apk update && apk add --update nodejs nodejs-npm python3 pkgconfig pixman-dev
+RUN apk update && apk add --update nodejs npm python3 pkgconfig pixman-dev
 RUN apk add --update cairo-dev pango-dev make g++
 
 COPY --from=tiktok_scraper.build ./usr/app ./


### PR DESCRIPTION
Pinned the base image for the docker builds to `alpine:3.14` rather than `latest`, and solved the issue where docker build failed (#620) due to the name of the npm package in alpine changing. It shouldn't have issues again because alpine is pinned (but who knows). :)