### PR TITLE
Fixing proxy issue

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -340,7 +340,7 @@ export class TikTokScraper extends EventEmitter {
                 followAllRedirects: followAllRedirects || false,
                 simple,
                 ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
-                ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
+                ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}` } : {}),
                 ...(this.strictSSL === false ? { rejectUnauthorized: false } : {}),
                 timeout: 10000,
             } as unknown) as OptionsWithUri;


### PR DESCRIPTION
When using proxy with username password and post , the backslash at the end cause to the request to fail. by removing it , it solves the problem