### PR TITLE
README: better docker params to run it

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,14 +208,14 @@ docker build . -t tiktok-scraper
 All files including history file will be saved in the directory(\$pwd) where you running the docker from
 
 ```sh
-docker run -v $(pwd):/usr/app/files tiktok-scraper user tiktok -d -n 5 -s
+docker run --rm -it -v $(pwd):/usr/app/files tiktok-scraper user tiktok -d -n 5 -s
 ```
 
 **Example 2:**
 All files including history file will be saved in /User/blah/downloads
 
 ```sh
-docker run -v /User/blah/downloads:/usr/app/files tiktok-scraper user tiktok -d -n 5 -s
+docker run --rm -it -v /User/blah/downloads:/usr/app/files tiktok-scraper user tiktok -d -n 5 -s
 ```
 
 ## Module


### PR DESCRIPTION
I have added `--rm -it` for better docker use.

- The required -i flag enables an interactive terminal to use commands within the container. [docs](https://docs.docker.com/engine/reference/commandline/run/#assign-name-and-allocate-pseudo-tty---name--it)
- The optional --rm flag removes the container filesystem on completion to prevent cruft build-up. [docs](https://docs.docker.com/engine/reference/run/#clean-up---rm)
- The optional -t flag allocates a pseudo-TTY which allows colored output. [docs](https://docs.docker.com/engine/reference/run/#foreground)
