### PR TITLE
Latest alpine version doesnt work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Building Scraper
-FROM alpine:latest AS tiktok_scraper.build
+FROM alpine:3.12 AS tiktok_scraper.build
 
 WORKDIR /usr/app
 
@@ -15,7 +15,7 @@ RUN rm -rf src node_modules
 
 
 #Using Scraper
-FROM alpine:latest AS tiktok_scraper.use
+FROM alpine:3.12 AS tiktok_scraper.use
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
I have seen several PRs on this , but those PRs still no working on my side.
None of this works for me #697 #680 #629 

Give me this error:

```
npm ERR! code 1
npm ERR! path /usr/app/node_modules/canvas                                                                
npm ERR! command failed                                                                                   
npm ERR! command sh -c node-pre-gyp install --fallback-to-build                                           
npm ERR! make: Entering directory '/usr/app/node_modules/canvas/build'                                    
npm ERR! make: Leaving directory '/usr/app/node_modules/canvas/build'                                     
npm ERR! Failed to execute '/usr/bin/node /usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/usr/app/node_modules/canvas/build/Release/canvas.node --module_name=canvas --module_path=/usr/app/node_modules/canvas/build/Release --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v83' (1)                                                          
npm ERR! node-pre-gyp info it worked if it ends with ok                                                   
npm ERR! node-pre-gyp info using node-pre-gyp@0.15.0                                                      
npm ERR! node-pre-gyp info using node@14.18.1 | linux | x64                                               
npm ERR! node-pre-gyp WARN Using request for node-pre-gyp https download                                  
npm ERR! node-pre-gyp info check checked for "/usr/app/node_modules/canvas/build/Release/canvas.node" (notfound)                                                                                                   
npm ERR! node-pre-gyp http GET https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v83-linux-musl-x64.tar.gz
npm ERR! node-pre-gyp http 404 https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v83-linux-musl-x64.tar.gz
npm ERR! node-pre-gyp WARN Tried to download(404): https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v83-linux-musl-x64.tar.gz
npm ERR! node-pre-gyp WARN Pre-built binaries not found for canvas@2.7.0 and node@14.18.1 (node-v83 ABI, musl) (falling back to source compile with node-gyp)
npm ERR! node-pre-gyp http 404 status code downloading tarball https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v83-linux-musl-x64.tar.gz
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@14.18.1 | linux | x64
npm ERR! gyp info ok
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@14.18.1 | linux | x64
npm ERR! gyp info find Python using Python version 3.9.5 found at "/usr/bin/python3"
npm ERR! gyp http GET https://nodejs.org/download/release/v14.18.1/node-v14.18.1-headers.tar.gz
npm ERR! gyp http 200 https://nodejs.org/download/release/v14.18.1/node-v14.18.1-headers.tar.gz
npm ERR! gyp http GET https://nodejs.org/download/release/v14.18.1/SHASUMS256.txt
npm ERR! gyp http 200 https://nodejs.org/download/release/v14.18.1/SHASUMS256.txt
npm ERR! gyp info spawn /usr/bin/python3
npm ERR! gyp info spawn args [
npm ERR! gyp info spawn args   '/usr/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
npm ERR! gyp info spawn args   'binding.gyp',
npm ERR! gyp info spawn args   '-f',
npm ERR! gyp info spawn args   'make',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/app/node_modules/canvas/build/config.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/usr/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
npm ERR! gyp info spawn args   '-I',
npm ERR! gyp info spawn args   '/root/.cache/node-gyp/14.18.1/include/node/common.gypi',
npm ERR! gyp info spawn args   '-Dlibrary=shared_library',
npm ERR! gyp info spawn args   '-Dvisibility=default',
npm ERR! gyp info spawn args   '-Dnode_root_dir=/root/.cache/node-gyp/14.18.1',
npm ERR! gyp info spawn args   '-Dnode_gyp_dir=/usr/lib/node_modules/npm/node_modules/node-gyp',
npm ERR! gyp info spawn args   '-Dnode_lib_file=/root/.cache/node-gyp/14.18.1/<(target_arch)/node.lib',
npm ERR! gyp info spawn args   '-Dmodule_root_dir=/usr/app/node_modules/canvas',
npm ERR! gyp info spawn args   '-Dnode_engine=v8',
npm ERR! gyp info spawn args   '--depth=.',
npm ERR! gyp info spawn args   '--no-parallel',
npm ERR! gyp info spawn args   '--generator-output',
npm ERR! gyp info spawn args   'build',
npm ERR! gyp info spawn args   '-Goutput_dir=.'
npm ERR! gyp info spawn args ]
npm ERR! gyp info ok
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@7.1.2
npm ERR! gyp info using node@14.18.1 | linux | x64
npm ERR! gyp info spawn make
npm ERR! gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
npm ERR! make: printf: Operation not permitted
npm ERR! make: *** [canvas-postbuild.target.mk:22: Release/obj.target/canvas-postbuild.node] Error 127
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:282:12)
npm ERR! gyp ERR! System Linux 5.4.0-7634-generic
npm ERR! gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/usr/app/node_modules/canvas/build/Release/canvas.node" "--module_name=canvas" "--module_path=/usr/app/node_modules/canvas/build/Release" "--napi_version=8" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=node-v83"
npm ERR! gyp ERR! cwd /usr/app/node_modules/canvas
npm ERR! gyp ERR! node -v v14.18.1
npm ERR! gyp ERR! node-gyp -v v7.1.2
npm ERR! gyp ERR! not ok
npm ERR! node-pre-gyp ERR! build error
npm ERR! node-pre-gyp ERR! stack Error: Failed to execute '/usr/bin/node /usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/usr/app/node_modules/canvas/build/Release/canvas.node --module_name=canvas --module_path=/usr/app/node_modules/canvas/build/Release --napi_version=8 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=node-v83' (1)
npm ERR! node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/usr/app/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
npm ERR! node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
npm ERR! node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1058:16)
npm ERR! node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:293:5)
npm ERR! node-pre-gyp ERR! System Linux 5.4.0-7634-generic
npm ERR! node-pre-gyp ERR! command "/usr/bin/node" "/usr/app/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
npm ERR! node-pre-gyp ERR! cwd /usr/app/node_modules/canvas
npm ERR! node-pre-gyp ERR! node -v v14.18.1
npm ERR! node-pre-gyp ERR! node-pre-gyp -v v0.15.0
npm ERR! node-pre-gyp ERR! not ok

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2021-11-01T20_40_21_905Z-debug.log
The command '/bin/sh -c npm i' returned a non-zero code: 1
```

So my propousal is fix alpine version to a working one.