### PR TITLE
Parse new tiktok page format to fix "Error: Can't extract video metadata"

### DIFF
--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1072,14 +1072,17 @@ export class TikTokScraper extends EventEmitter {
             json: true,
         };
         try {
+
             const response = await this.request<string>(options);
+
             const breakResponse = response
-                .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
-                .split(`</script>`)[0];
+            .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
+            .split(`</script>`)[0];
             if (breakResponse) {
                 const userMetadata: WebHtmlUserMetadata = JSON.parse(breakResponse);
                 return userMetadata.props.pageProps.userInfo;
             }
+
         } catch (err) {
             if (err.statusCode === 404) {
                 throw new Error('User does not exist');
@@ -1201,13 +1204,29 @@ export class TikTokScraper extends EventEmitter {
                 throw new Error(`Can't extract video meta data`);
             }
 
-            const rawVideoMetadata = response
+            if (response.includes("__NEXT_DATA__")){
+                const rawVideoMetadata = response
                 .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
                 .split(`</script>`)[0];
 
-            const videoProps = JSON.parse(rawVideoMetadata);
-            const videoData = videoProps.props.pageProps.itemInfo.itemStruct;
-            return videoData as FeedItems;
+                const videoProps = JSON.parse(rawVideoMetadata);
+                const videoData = videoProps.props.pageProps.itemInfo.itemStruct;
+                return videoData as FeedItems;
+            }
+
+            if (response.includes("SIGI_STATE")) {
+                // Sometimes you may receive a state in different format, so we should parse it too
+                // New format - https://pastebin.com/WLUpL0ei
+                const rawVideoMetadata = response
+                    .split("window['SIGI_STATE']=")[1]
+                    .split(";window['SIGI_RETRY']=")[0];
+
+                const videoProps = JSON.parse(rawVideoMetadata);
+                const videoData = Object.values(videoProps.ItemModule)[0];
+                return <FeedItems>videoData;
+            }
+
+            throw new Error('No available parser for html page')
         } catch (error) {
             throw new Error(`Can't extract video metadata: ${this.input}`);
         }

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1072,9 +1072,7 @@ export class TikTokScraper extends EventEmitter {
             json: true,
         };
         try {
-
             const response = await this.request<string>(options);
-
             const breakResponse = response
                 .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
                 .split(`</script>`)[0];
@@ -1082,7 +1080,6 @@ export class TikTokScraper extends EventEmitter {
                 const userMetadata: WebHtmlUserMetadata = JSON.parse(breakResponse);
                 return userMetadata.props.pageProps.userInfo;
             }
-
         } catch (err) {
             if (err.statusCode === 404) {
                 throw new Error('User does not exist');

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1076,8 +1076,8 @@ export class TikTokScraper extends EventEmitter {
             const response = await this.request<string>(options);
 
             const breakResponse = response
-            .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
-            .split(`</script>`)[0];
+                .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
+                .split(`</script>`)[0];
             if (breakResponse) {
                 const userMetadata: WebHtmlUserMetadata = JSON.parse(breakResponse);
                 return userMetadata.props.pageProps.userInfo;

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1206,8 +1206,8 @@ export class TikTokScraper extends EventEmitter {
 
             if (response.includes("__NEXT_DATA__")){
                 const rawVideoMetadata = response
-                .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
-                .split(`</script>`)[0];
+                    .split(/<script id="__NEXT_DATA__" type="application\/json" nonce="[\w-]+" crossorigin="anonymous">/)[1]
+                    .split(`</script>`)[0];
 
                 const videoProps = JSON.parse(rawVideoMetadata);
                 const videoData = videoProps.props.pageProps.itemInfo.itemStruct;

--- a/src/core/TikTok.ts
+++ b/src/core/TikTok.ts
@@ -1220,7 +1220,7 @@ export class TikTokScraper extends EventEmitter {
 
                 const videoProps = JSON.parse(rawVideoMetadata);
                 const videoData = Object.values(videoProps.ItemModule)[0];
-                return <FeedItems>videoData;
+                return videoData as FeedItems;
             }
 
             throw new Error('No available parser for html page')


### PR DESCRIPTION
Hello! 
Recently I was struggling with a problem: very often I received an error "Error: Can't extract video metadata".
I've seen that sometimes TikTok returns a page, in which data is stored in a different format. I've added a parser, which will help to receive proper data for that case.

There is no need to merge this PR in this particular implementation, but I hope it will help somebody who struggles with a similar issue.